### PR TITLE
Remove truncate from story descriptions

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -431,7 +431,7 @@ function get_top_story_details() {
 
 					$details['thumbnail_src']     = remove_quotes($enclosure->get_thumbnail());
 					$details['story_title']       = sanitize_for_email($rss_item->get_title());
-					$details['story_description'] = truncate(sanitize_for_email($rss_item->get_description()));
+					$details['story_description'] = sanitize_for_email($rss_item->get_description());
 					$details['read_more_uri']     = remove_quotes($rss_item->get_permalink());
 
 					if($details['thumbnail_src'] != '') {
@@ -480,7 +480,7 @@ function get_featured_stories_details() {
 					$story['thumbnail_src'] = remove_quotes(get_bloginfo('stylesheet_directory', 'raw').'/static/img/no-photo.png');
 				}
 				$story['title']       = sanitize_for_email($rss_item->get_title());
-				$story['description'] = truncate(sanitize_for_email($rss_item->get_description()));
+				$story['description'] = sanitize_for_email($rss_item->get_description());
 				$story['permalink']   = remove_quotes($rss_item->get_permalink());
 				array_push($stories, $story);
 				$count++;

--- a/includes/news/mail/featured-stories.php
+++ b/includes/news/mail/featured-stories.php
@@ -21,7 +21,7 @@
 							</a>
 						</div>
 						<a href="<?=$permalink?>" style="color:#000001;text-decoration:none;">
-							<span style="font-weight:200;font-size:14px;line-height:1.4em;color:#000001;"><?=truncate($description, 25)?></span>
+							<span style="font-weight:200;font-size:14px;line-height:1.4em;color:#000001;"><?=$description?></span>
 						</a>
 					</td>
 				</tr>


### PR DESCRIPTION
Updates:
- Removed truncate from story description, that content will now be truncated before being put into the Today RSS feed's `<description>` element

This PR coincides with the 'Add Promo Custom Field & Update Description Element' PR for Today-Bootstrap.