### PR TITLE
Removed incoming event sorting

### DIFF
--- a/includes/events-functions.php
+++ b/includes/events-functions.php
@@ -8,27 +8,6 @@ use GMUCF\Theme\Includes\Utilities;
 
 
 /**
- * Compare events based on start time
- *
- * @return integer
- * @author Chris Conover
- **/
-function compare_event_starts($a, $b) {
-	// Just take into account the time part of the start date time.
-	// Otherwise events that are ongoing would be put in front.
-	$a_parts = explode(' ', $a->starts);
-	$b_parts = explode(' ', $b->starts);
-	$a_start = strtotime($a_parts[4]);
-	$b_start = strtotime($b_parts[4]);
-	if($a_start == $b_start) {
-		return 0;
-	} else {
-		return ($a_start > $b_start) ? +1 : -1;
-	}
-}
-
-
-/**
  * Fetch events from UCF event system (with caching)
  *
  * @return array
@@ -74,9 +53,6 @@ function get_event_data($options = array()) {
 		}
 
 		curl_close($ch);
-
-		// Events aren't neccessarily sorted from earliest to latest start time
-		usort($events, __NAMESPACE__ . '\compare_event_starts');
 
 		if(isset($options['limit']) && count($events) > $options['limit']) {
 			$events = array_slice($events, 0, $options['limit']);


### PR DESCRIPTION
Removed an unnecessary and expensive `usort` on incoming events feed data.  Our events system returns events in the correct order (unlike the previous iteration of the events system, for which this logic was originally designed), so this extra step is no longer necessary.

Resolves #69 