### PR TITLE
Gmucf template redirects

### DIFF
--- a/includes/template-redirect-functions.php
+++ b/includes/template-redirect-functions.php
@@ -29,25 +29,25 @@ function display_gmucf_template( $template ) {
  * @return void
  */
 function gmucf_template_redirect() {
-	// Get the path component
-    $request_path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-    $request_path = ltrim($request_path, '/'); // Remove leading slash
+	// Get the path without server host or leading blog stuff (e.g. /wp3/gmucf)
+	$site_path = parse_url( get_site_url() )['path'];
+	$request_path = substr( str_replace( $site_path, '', $_SERVER['REQUEST_URI'] ), 1 );
 
 	// Most to least specific
 	$mapping = array(
-		'gmucf/news/mail/'           => function() { display_gmucf_template( 'template-parts/news/mail/base' ); },
-		'gmucf/news/text/'           => function() { display_gmucf_template( 'template-parts/news/text/base' ); },
-		'gmucf/news/'                => function() { display_gmucf_template( 'template-parts/news/browser/base' ); },
-		'gmucf/events/weekday/mail/' => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/mail/base' ); },
-		'gmucf/events/weekday/text/' => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/text/base' ); },
-		'gmucf/events/weekday/'      => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/browser/base' ); },
-		'gmucf/events/weekend/mail/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/mail/base' ); },
-		'gmucf/events/weekend/text/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/text/base' ); },
-		'gmucf/events/weekend/'      => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/browser/base' ); },
-		'gmucf/coronavirus/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
-		'gmucf/coronavirus/'  		 => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
-		'gmucf/icymi/mail/'    		 => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
-		'gmucf/icymi/'         		 => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
+		'news/mail/'           => function() { display_gmucf_template( 'template-parts/news/mail/base' ); },
+		'news/text/'           => function() { display_gmucf_template( 'template-parts/news/text/base' ); },
+		'news/'                => function() { display_gmucf_template( 'template-parts/news/browser/base' ); },
+		'events/weekday/mail/' => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/mail/base' ); },
+		'events/weekday/text/' => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/text/base' ); },
+		'events/weekday/'      => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/browser/base' ); },
+		'events/weekend/mail/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/mail/base' ); },
+		'events/weekend/text/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/text/base' ); },
+		'events/weekend/'      => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/browser/base' ); },
+		'coronavirus/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
+		'coronavirus/'         => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
+		'icymi/mail/'    	   => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
+		'icymi/'         	   => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); }
 
 	);
 

--- a/includes/template-redirect-functions.php
+++ b/includes/template-redirect-functions.php
@@ -45,9 +45,9 @@ function gmucf_template_redirect() {
 		'gmucf/events/weekend/text/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/text/base' ); },
 		'gmucf/events/weekend/'      => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/browser/base' ); },
 		'gmucf/coronavirus/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
-		'gmucf/coronavirus/'  => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
-		'gmucf/icymi/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
-		'gmucf/icymi/'         => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
+		'gmucf/coronavirus/'  		 => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
+		'gmucf/icymi/mail/'    		 => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
+		'gmucf/icymi/'         		 => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
 
 	);
 

--- a/includes/template-redirect-functions.php
+++ b/includes/template-redirect-functions.php
@@ -32,7 +32,7 @@ function gmucf_template_redirect() {
 	// Get the path component
     $request_path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
     $request_path = ltrim($request_path, '/'); // Remove leading slash
-	var_dump($request_path);
+
 	// Most to least specific
 	$mapping = array(
 		'gmucf/news/mail/'           => function() { display_gmucf_template( 'template-parts/news/mail/base' ); },

--- a/includes/template-redirect-functions.php
+++ b/includes/template-redirect-functions.php
@@ -35,18 +35,18 @@ function gmucf_template_redirect() {
 	var_dump($request_path);
 	// Most to least specific
 	$mapping = array(
-		'news/mail/'           => function() { display_gmucf_template( 'template-parts/news/mail/base' ); },
-		'news/text/'           => function() { display_gmucf_template( 'template-parts/news/text/base' ); },
-		'news/'                => function() { display_gmucf_template( 'template-parts/news/browser/base' ); },
-		'events/weekday/mail/' => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/mail/base' ); },
-		'events/weekday/text/' => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/text/base' ); },
-		'events/weekday/'      => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/browser/base' ); },
-		'events/weekend/mail/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/mail/base' ); },
-		'events/weekend/text/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/text/base' ); },
-		'events/weekend/'      => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/browser/base' ); },
-		'coronavirus/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
+		'gmucf/news/mail/'           => function() { display_gmucf_template( 'template-parts/news/mail/base' ); },
+		'gmucf/news/text/'           => function() { display_gmucf_template( 'template-parts/news/text/base' ); },
+		'gmucf/news/'                => function() { display_gmucf_template( 'template-parts/news/browser/base' ); },
+		'gmucf/events/weekday/mail/' => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/mail/base' ); },
+		'gmucf/events/weekday/text/' => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/text/base' ); },
+		'gmucf/events/weekday/'      => function() { $_GET['edition'] = 'weekday'; display_gmucf_template( 'template-parts/events/browser/base' ); },
+		'gmucf/events/weekend/mail/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/mail/base' ); },
+		'gmucf/events/weekend/text/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/text/base' ); },
+		'gmucf/events/weekend/'      => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/browser/base' ); },
+		'gmucf/coronavirus/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
 		'gmucf/coronavirus/'  => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
-		'gmucf/icymi/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
+		'gmucf/icymi/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
 		'gmucf/icymi/'         => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
 
 	);

--- a/includes/template-redirect-functions.php
+++ b/includes/template-redirect-functions.php
@@ -29,9 +29,10 @@ function display_gmucf_template( $template ) {
  * @return void
  */
 function gmucf_template_redirect() {
-	// Get the path without server host or leading blog stuff (e.g. /wp3/gmucf)
-	$request_path = substr( $_SERVER['REQUEST_URI'], 1 );
-
+	// Get the path component
+    $request_path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+    $request_path = ltrim($request_path, '/'); // Remove leading slash
+	var_dump($request_path);
 	// Most to least specific
 	$mapping = array(
 		'news/mail/'           => function() { display_gmucf_template( 'template-parts/news/mail/base' ); },
@@ -44,12 +45,16 @@ function gmucf_template_redirect() {
 		'events/weekend/text/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/text/base' ); },
 		'events/weekend/'      => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/browser/base' ); },
 		'coronavirus/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
-		'coronavirus/'         => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); }
+		'gmucf/coronavirus/'  => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
+		'gmucf/icymi/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
+		'gmucf/icymi/'         => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
+
 	);
 
 	foreach ( $mapping as $path => $func ) {
 		if ( stripos( $request_path, $path ) === 0 ) {
 			call_user_func( $func );
+			return;
 		}
 	}
 }


### PR DESCRIPTION
- Added two additional pathways : 'icymi/' and 'icymi/mail/' 
- Added the logic to apply redirection when we use main directory & subdirectory for good morning UCF website. 
<img width="1664" alt="Screenshot 2024-09-19 at 1 42 50 PM" src="https://github.com/user-attachments/assets/3cf47b5f-3ff5-48d5-9e71-df0e3fbcad85">

