### PR TITLE
Updated to deal with responses that do not throw a WP_Error

### DIFF
--- a/includes/announcements-functions.php
+++ b/includes/announcements-functions.php
@@ -77,8 +77,7 @@ function get_announcement_details( $announcement_ids=array() ) {
 			);
 		}
 	} else {
-		$error_string = $response->get_error_message();
-		error_log( "GMUCF - get_announcement_details() - " . $error_string );
+		error_log( "GMUCF - get_announcement_details() - " . $response_code );
 	}
 
 	return array_slice( $announcements, 0, 3 );

--- a/includes/in-the-news-functions.php
+++ b/includes/in-the-news-functions.php
@@ -26,6 +26,7 @@ function get_in_the_news_stories() {
 	$arg_string = '?' . http_build_query( $args );
 
 	$response = wp_remote_get( $json_url . $arg_string, array( 'timeout' => $timeout ) );
+	$response_code = wp_remote_retrieve_response_code( $response );
 
 	if ( is_array( $response ) ) {
 		$items = json_decode( wp_remote_retrieve_body( $response ) );
@@ -34,8 +35,7 @@ function get_in_the_news_stories() {
 			$stories = $items;
 		}
 	} else {
-		$error_string = $response->get_error_message();
-		error_log( "GMUCF - get_in_the_news_stories() - " . $error_string );
+		error_log( "GMUCF - get_in_the_news_stories() - " . $response_code );
 	}
 
 	return $stories;

--- a/includes/ucf-today-functions.php
+++ b/includes/ucf-today-functions.php
@@ -90,6 +90,8 @@ function get_gmucf_email_options_feed_values() {
 		array( 'timeout' => $options_timeout )
 	);
 
+	$response_code = wp_remote_retrieve_response_code( $response );
+
 	if ( is_array( $response ) ) {
 		$items = json_decode( wp_remote_retrieve_body( $response ) );
 
@@ -97,8 +99,7 @@ function get_gmucf_email_options_feed_values() {
 			$gmucf_email_options = $items;
 		}
 	} else {
-		$error_string = $response->get_error_message();
-		error_log( 'GMUCF - get_gmucf_email_options_feed_values() - ' . $error_string );
+		error_log( 'GMUCF - get_gmucf_email_options_feed_values() - ' . $response_code );
 	}
 
 	return $gmucf_email_options;

--- a/template-parts/news/mail/base.php
+++ b/template-parts/news/mail/base.php
@@ -63,7 +63,6 @@ $current_date = current_datetime();
                                   <?php echo get_template_part( 'template-parts/news/mail/in-the-news' ); ?>
                                 </td>
                               </tr>
-                              <?php echo get_template_part( 'template-parts/news/mail/announcements' ); ?>
                               <?php echo get_template_part( 'template-parts/news/mail/footer' ); ?>
                             </tbody>
                           </table>


### PR DESCRIPTION
* There are times when the response we get back isn't what we want, but it is not an error. Instead of trying to log the error, I'm recording the status code.